### PR TITLE
fix(nginx): use number for boolean

### DIFF
--- a/egg-nginx.json
+++ b/egg-nginx.json
@@ -42,7 +42,7 @@
             "name": "Wordpress",
             "description": "Enable or disable Wordpress\r\n\r\n0 = false (default)\r\n1 = true",
             "env_variable": "WORDPRESS",
-            "default_value": "false",
+            "default_value": "0",
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|boolean",

--- a/egg-nginx.json
+++ b/egg-nginx.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2022-06-23T23:05:44+02:00",
+    "exported_at": "2024-02-20T08:00:56+08:00",
     "name": "Nginx",
     "author": "cali@oryzen.xyz",
     "description": "An Nginx egg to host any Website",


### PR DESCRIPTION
Pterodactyl, for booleans, does not allow `true` or `false`, it required `0` for `false` or `1` for `true`.